### PR TITLE
Fix updating market fragment per seconds

### DIFF
--- a/app/src/main/java/vn/realtest/stock/justanewproject/Activities/MainActivity.java
+++ b/app/src/main/java/vn/realtest/stock/justanewproject/Activities/MainActivity.java
@@ -31,7 +31,7 @@ import vn.realtest.stock.justanewproject.Utils.UrlEndpoints;
 public class MainActivity extends AppCompatActivity {
     TextView mTitleTv;
 
-    private static final long TIMEFORRELOADING = 60 * 1000; // 1 minute
+    private static final long TIMEFORRELOADING = 15 * 1000; // 1 minute
 
     private BottomNavigationView.OnNavigationItemSelectedListener mOnNavigationItemSelectedListener
             = new BottomNavigationView.OnNavigationItemSelectedListener() {
@@ -121,7 +121,6 @@ public class MainActivity extends AppCompatActivity {
             @Override
             public void OnStockModel(ArrayList<Stock> stocks) {
                 StockStorage.SetGlobalStockDataByType(type, stocks);
-
             }
 
             @Override

--- a/app/src/main/java/vn/realtest/stock/justanewproject/Fragments/HnxFragment.java
+++ b/app/src/main/java/vn/realtest/stock/justanewproject/Fragments/HnxFragment.java
@@ -56,7 +56,7 @@ public class HnxFragment extends Fragment {
         parseStockData(marketStockList, StockStorage.getGlobalStockDataByType(stockType));
         mAdapter.notifyDataSetChanged();
 
-        StockStorage.AddOnDataLoadedListener(new OnDataLoadedListener() {
+        StockStorage.AddOnDataLoadedListener(stockType, new OnDataLoadedListener() {
             @Override
             public void OnStockDataParsed() {
                 Log.d("test", "onGlobalDataChanged");
@@ -69,6 +69,7 @@ public class HnxFragment extends Fragment {
 
     private void parseStockData(List<MarketStock> marketStockList, ArrayList<Stock> stocks) {
         if (stocks != null && !stocks.isEmpty()) {
+            marketStockList.clear();
             for(Stock stock : stocks) {
                 marketStockList.add(new MarketStock(
                         stock.getID() + "",

--- a/app/src/main/java/vn/realtest/stock/justanewproject/Fragments/HoseFragment.java
+++ b/app/src/main/java/vn/realtest/stock/justanewproject/Fragments/HoseFragment.java
@@ -55,7 +55,7 @@ public class HoseFragment extends Fragment {
         parseStockData(marketStockList, StockStorage.getGlobalStockDataByType(stockType));
         mAdapter.notifyDataSetChanged();
 
-        StockStorage.AddOnDataLoadedListener(new OnDataLoadedListener() {
+        StockStorage.AddOnDataLoadedListener(stockType, new OnDataLoadedListener() {
             @Override
             public void OnStockDataParsed() {
                 parseStockData(marketStockList, StockStorage.getGlobalStockDataByType(stockType));
@@ -68,6 +68,7 @@ public class HoseFragment extends Fragment {
 
     private void parseStockData(List<MarketStock> marketStockList, ArrayList<Stock> stocks) {
         if (stocks != null && !stocks.isEmpty()) {
+            marketStockList.clear();
             for(Stock stock : stocks) {
                 marketStockList.add(new MarketStock(
                         stock.getID() + "",

--- a/app/src/main/java/vn/realtest/stock/justanewproject/Fragments/TradeFragment.java
+++ b/app/src/main/java/vn/realtest/stock/justanewproject/Fragments/TradeFragment.java
@@ -82,7 +82,7 @@ public class TradeFragment extends Fragment implements AdapterView.OnItemSelecte
 
         getData();
 
-        StockStorage.AddOnDataLoadedListener(new OnDataLoadedListener() {
+        StockStorage.AddOnDataLoadedListener(StockType.HNX, new OnDataLoadedListener() {
             @Override
             public void OnStockDataParsed() {
                 getData();

--- a/app/src/main/java/vn/realtest/stock/justanewproject/Fragments/UpcomFragment.java
+++ b/app/src/main/java/vn/realtest/stock/justanewproject/Fragments/UpcomFragment.java
@@ -55,7 +55,7 @@ public class UpcomFragment extends Fragment {
         parseStockData(marketStockList, StockStorage.getGlobalStockDataByType(stockType));
         mAdapter.notifyDataSetChanged();
 
-        StockStorage.AddOnDataLoadedListener(new OnDataLoadedListener() {
+        StockStorage.AddOnDataLoadedListener(stockType, new OnDataLoadedListener() {
             @Override
             public void OnStockDataParsed() {
                 parseStockData(marketStockList, StockStorage.getGlobalStockDataByType(stockType));
@@ -68,6 +68,7 @@ public class UpcomFragment extends Fragment {
 
     private void parseStockData(List<MarketStock> marketStockList, ArrayList<Stock> stocks) {
         if (stocks != null && !stocks.isEmpty()) {
+            marketStockList.clear();
             for(Stock stock : stocks) {
                 marketStockList.add(new MarketStock(
                         stock.getID() + "",

--- a/app/src/main/java/vn/realtest/stock/justanewproject/Utils/GlobalStorage/StockStorage.java
+++ b/app/src/main/java/vn/realtest/stock/justanewproject/Utils/GlobalStorage/StockStorage.java
@@ -1,6 +1,8 @@
 package vn.realtest.stock.justanewproject.Utils.GlobalStorage;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 import vn.realtest.stock.justanewproject.Models.Stock;
 import vn.realtest.stock.justanewproject.Models.StockType;
@@ -11,11 +13,17 @@ import vn.realtest.stock.justanewproject.Models.StockType;
 
 public class StockStorage {
 
-    private static ArrayList<OnDataLoadedListener> onDataLoadedListeners = new ArrayList<>();
+    private static Map<StockType, ArrayList<OnDataLoadedListener>> onDataLoadedListeners = new HashMap<>();
 
-    public static void AddOnDataLoadedListener(OnDataLoadedListener onDataLoadedListener) {
-        if (onDataLoadedListener != null) {
-            onDataLoadedListeners.add(onDataLoadedListener);
+    public static void AddOnDataLoadedListener(StockType stockType, OnDataLoadedListener onDataLoadedListener) {
+        if (stockType != null && onDataLoadedListener != null) {
+            if (onDataLoadedListeners.containsKey(stockType)) {
+                onDataLoadedListeners.get(stockType).add(onDataLoadedListener);
+            } else {
+                ArrayList<OnDataLoadedListener> onDataLoadedListenerList = new ArrayList<>();
+                onDataLoadedListenerList.add(onDataLoadedListener);
+                onDataLoadedListeners.put(stockType, onDataLoadedListenerList);
+            }
         }
     }
 
@@ -34,12 +42,15 @@ public class StockStorage {
             case HOSE: GlobalData.HOSE = stocks; break;
             case UPCOM: GlobalData.UPCOM = stocks; break;
         }
-        onGlobalDataChanged();
+        onGlobalDataChanged(type);
     }
 
-    private static void onGlobalDataChanged() {
-        for (OnDataLoadedListener onDataLoadedListener : onDataLoadedListeners) {
-            onDataLoadedListener.OnStockDataParsed();
+    private static void onGlobalDataChanged(StockType stockType) {
+        if (stockType != null && onDataLoadedListeners.containsKey(stockType)) {
+            ArrayList<OnDataLoadedListener> onDataLoadedListenerList = onDataLoadedListeners.get(stockType);
+            for (OnDataLoadedListener onDataLoadedListener : onDataLoadedListenerList) {
+                onDataLoadedListener.OnStockDataParsed();
+            }
         }
     }
 


### PR DESCRIPTION
I've forgotten to clear the list before updating it. What a horrible mistake :disappointed_relieved: 
Besides, I've changed the way that listeners will listen to the storage, so it can prevent duplicated times for each listener